### PR TITLE
Adds CMakeLists to proto/gen folder.

### DIFF
--- a/proto/gen/CMakeLists.txt
+++ b/proto/gen/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB srcs *.cc)
+add_library(protos ${srcs})
+target_include_directories(protos PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This helps projects that add this one as a submodule to build the generated C++ code with CMake.